### PR TITLE
Move render initialization into main loop

### DIFF
--- a/game.js
+++ b/game.js
@@ -261,8 +261,6 @@ class Game {
   }
 
   initialize() {
-    this.render.initialize(this.lane.width, this.lane.height, this.lane.gutterWidth);
-
     this.render.setupPointerDownListener(this.pointerDownCallback.bind(this));
     this.render.setupPointerMoveListener(this.pointerMoveCallback.bind(this));
     this.render.setupPointerEndListener(this.pointerEndCallback.bind(this));
@@ -397,7 +395,6 @@ class Game {
 
     self = this;
     function runHelper(timestamp) {
-      self.render.initialize(self.lane.width, self.lane.height, self.lane.gutterWidth);
       self.engine.update(self.ball, self.pins, self.lane, self.ticker.tickInterval(timestamp));
       self.render.draw(self.ball, self.pins, self.lane, self.frames, self.gameState);
       self.handleGameState(false)

--- a/game.js
+++ b/game.js
@@ -397,6 +397,7 @@ class Game {
 
     self = this;
     function runHelper(timestamp) {
+      self.render.initialize(self.lane.width, self.lane.height, self.lane.gutterWidth);
       self.engine.update(self.ball, self.pins, self.lane, self.ticker.tickInterval(timestamp));
       self.render.draw(self.ball, self.pins, self.lane, self.frames, self.gameState);
       self.handleGameState(false)

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       margin: 10px auto;
       color: white;
       font-size: .7em;
+      min-width: 300px;
     }
     table {
       border-collapse: collapse;

--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
       margin: 10px auto;
       color: white;
       font-size: .7em;
-      min-width: 300px;
     }
     table {
       border-collapse: collapse;

--- a/render.js
+++ b/render.js
@@ -434,6 +434,7 @@ export class Render {
   }
   
   draw(ball, pins, lane, frames, gameState) {
+    this.initialize(lane.width, lane.height, lane.gutterWidth);
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     this.drawLane(lane);
     this.drawPins(pins);

--- a/render.js
+++ b/render.js
@@ -142,13 +142,13 @@ export class Render {
     // Resize scoreboard to match canvas width
     this.scoreboard.style.width = `${this.canvas.style.width}px`;
 
-    console.log(`Render initialization complete. 
-    available canvas: ${availableCanvasWidth}x${availableCanvasHeight}, 
-    scaled canvas: ${this.canvas.width}x${this.canvas.height}, 
-    renderScale: ${this.renderScale},
-    widthRatio: ${widthRatio}, 
-    heightRatio: ${heightRatio},
-    devicePixelRatio: ${window.devicePixelRatio}`);
+    // console.log(`Render initialization complete. 
+    // available canvas: ${availableCanvasWidth}x${availableCanvasHeight}, 
+    // scaled canvas: ${this.canvas.width}x${this.canvas.height}, 
+    // renderScale: ${this.renderScale},
+    // widthRatio: ${widthRatio}, 
+    // heightRatio: ${heightRatio},
+    // devicePixelRatio: ${window.devicePixelRatio}`);
   }
 
   /**
@@ -164,7 +164,7 @@ export class Render {
    * This fits "more canvas" into the same dimensions.
    */
   scalePPI(canvas, scaleFactor) {
-    console.log(`setting PPI with scaleFactor ${scaleFactor}`);
+    // console.log(`setting PPI with scaleFactor ${scaleFactor}`);
 
     // Set up CSS size.
     canvas.style.width = canvas.width + 'px';


### PR DESCRIPTION
Sometimes browser is slow to render so initializing once gives inaccurate dimensions.